### PR TITLE
Fix fontification performance bug

### DIFF
--- a/orglink.el
+++ b/orglink.el
@@ -132,7 +132,7 @@ On the links the following commands are available:
          (kill-local-variable 'org-descriptive-links)
          (kill-local-variable 'font-lock-unfontify-region-function)
          (kill-local-variable 'org-mouse-map)))
-  (font-lock-fontify-buffer))
+  (when font-lock-fontified (font-lock-fontify-buffer)))
 
 ;;;###autoload
 (define-globalized-minor-mode global-orglink-mode


### PR DESCRIPTION
Merci vielmal for orglink! Universal Org links have been on my todo list for months.

This patch fixes a curious performance issue.

On my Emacs 24.3.1 system, the following benchmark shows a massive performance drop
when loading a huge C++ file. Unpatched orglink: 0.9 sec vs. patched: 0.04 sec.

```
git clone git://github.com/nonsequitur/show-performance-bug.git
HOME=show-performance-bug emacs --no-splash
```

I wonder what causes this. It can't be the fontification running twice.
