### PR TITLE
Fix text link opening

### DIFF
--- a/orglink.el
+++ b/orglink.el
@@ -174,8 +174,8 @@ On the links the following commands are available:
                       "\\(?:\\sw+\\)")
                     "?" s)
             nil t)
-           (setq pos (match-beginning 0))))
-    (goto-char pos)))
+           (setq pos (match-beginning 0))
+           (goto-char pos)))))
 
 (provide 'orglink)
 ;; Local Variables:


### PR DESCRIPTION
Currently, opening most text links results in a type error in `orglink-heading-link-search`. Here's a fix.

Maybe `orglink-heading-link-search` isn't even needed at all.
Org's built-in fuzzy link search works fine for me when the link text is prefixed.
